### PR TITLE
Enforce upper-case on login authentication codes

### DIFF
--- a/SteamNotificationsTray/LoginForm.Designer.cs
+++ b/SteamNotificationsTray/LoginForm.Designer.cs
@@ -200,6 +200,7 @@
             // 
             this.emailAuthTextBox.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
+            this.emailAuthTextBox.CharacterCasing = System.Windows.Forms.CharacterCasing.Upper;
             this.emailAuthTextBox.Location = new System.Drawing.Point(3, 16);
             this.emailAuthTextBox.Name = "emailAuthTextBox";
             this.emailAuthTextBox.Size = new System.Drawing.Size(250, 20);
@@ -234,6 +235,7 @@
             // 
             this.mobileAuthTextBox.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
+            this.mobileAuthTextBox.CharacterCasing = System.Windows.Forms.CharacterCasing.Upper;
             this.mobileAuthTextBox.Location = new System.Drawing.Point(3, 16);
             this.mobileAuthTextBox.Name = "mobileAuthTextBox";
             this.mobileAuthTextBox.Size = new System.Drawing.Size(250, 20);


### PR DESCRIPTION
As is the behavior in Steam's own UI (both the app and the website), entering either the mobile authenticator code, or the Steam Guard code, lower-case letters are automatically transformed to upper-case.
This small UI fix makes this behavior consistent with the notification tray login dialog.

_I was thinking about setting the `MaxLength` to 5 as well, but as Steam's own UI does not do this, it's best to leave it as it is._